### PR TITLE
Add leading zeros when converting base

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.0
+version: 1.1.1
 init:
   - if %APPVEYOR_REPO_TAG%==false (appveyor UpdateBuild -Version "%APPVEYOR_BUILD_VERSION%-build%APPVEYOR_BUILD_NUMBER%")
 skip_branch_with_pr: true

--- a/src/Base62/EncodingExtensions.cs
+++ b/src/Base62/EncodingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Base62
@@ -153,6 +154,7 @@ namespace Base62
         private static int[] BaseConvert(int[] source, int sourceBase, int targetBase)
         {
             var result = new List<int>();
+            var leadingZeroCount = source.TakeWhile(x => x == 0).Count();
             int count;
             while ((count = source.Length) > 0)
             {
@@ -172,7 +174,7 @@ namespace Base62
                 result.Insert(0, remainder);
                 source = quotient.ToArray();
             }
-
+            result.InsertRange(0, Enumerable.Repeat(0, leadingZeroCount));
             return result.ToArray();
         }
     }

--- a/tests/Base62.Tests/BasicTests.cs
+++ b/tests/Base62.Tests/BasicTests.cs
@@ -46,5 +46,14 @@ namespace Base62.Tests
             var i = "14q60P".FromBase62<int>();
             Assert.Equal(987654321, i);
         }
+
+        [Fact]
+        public void ByteArrayConversionIdentityTest()
+        {
+            var bytes = new byte[] { 0, 0, 0, 128, 128, 0, 0, 1, 2, 3, 0, 0, 0 };
+            string s = bytes.ToBase62();
+            byte[] back = s.FromBase62();
+            Assert.Equal(bytes, back);
+        }
     }
 }


### PR DESCRIPTION
This should fix #1 
I also added a test case to ensure this property holds forever.