### PR TITLE
Changed BaseConvert to only count n-1 leading zeros

### DIFF
--- a/src/Base62/EncodingExtensions.cs
+++ b/src/Base62/EncodingExtensions.cs
@@ -154,7 +154,7 @@ namespace Base62
         private static int[] BaseConvert(int[] source, int sourceBase, int targetBase)
         {
             var result = new List<int>();
-            var leadingZeroCount = source.TakeWhile(x => x == 0).Count();
+            var leadingZeroCount = Math.Min(source.TakeWhile(x => x == 0).Count(), source.Length - 1);
             int count;
             while ((count = source.Length) > 0)
             {

--- a/tests/Base62.Tests/BasicTests.cs
+++ b/tests/Base62.Tests/BasicTests.cs
@@ -55,5 +55,25 @@ namespace Base62.Tests
             byte[] back = s.FromBase62();
             Assert.Equal(bytes, back);
         }
+
+        [Fact]
+        public void ByteArrayConversionZeroArray()
+        {
+            var bytes = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            string s = bytes.ToBase62();
+            byte[] back = s.FromBase62();
+            Assert.Equal(bytes.Length, back.Length);
+            Assert.Equal(bytes, back);
+        }
+
+        [Fact]
+        public void ByteArrayConversionAlmostZeroArray()
+        {
+            var bytes = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+            string s = bytes.ToBase62();
+            byte[] back = s.FromBase62();
+            Assert.Equal(bytes.Length, back.Length);
+            Assert.Equal(bytes, back);
+        }
     }
 }


### PR DESCRIPTION
as a final zero is always added. Handles the case for a byte array of all zeros. Added test cases to verify.